### PR TITLE
Adding public-uuid based sharing link for trees

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,12 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  before_action :authenticate_user!, unless: :devise_controller?
+  before_action :authenticate_user!, unless: :skip_authentication?
 
   private
+
+  def skip_authentication?
+    devise_controller?
+  end
 
   def set_flash_error(object)
     flash[:error] = object.errors.full_messages.join('.')

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -15,6 +15,12 @@ class TreesController < ApplicationController
 
   private
 
+  def skip_authentication?
+    @resource = Tree.find_by(public_uuid: params[:id])
+    return true if @resource
+    super
+  end
+
   def convert_to_trees
     @trees = resource_collection
   end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -4,6 +4,12 @@ class Tree < ActiveRecord::Base
   has_many :objectives
   belongs_to :user
 
+  validates :public_uuid, presence: true
+
+  before_validation do
+    self.public_uuid ||= SecureRandom::uuid()
+  end
+
   def roots
     objectives.roots
   end

--- a/app/views/trees/show.slim
+++ b/app/views/trees/show.slim
@@ -16,3 +16,4 @@ div.tree-container style="height: #{@tree.roots_width*250}px;"
                   - node.objective_traits.each do |trait|
                     li= "#{trait.amount >= 0 ? '+' : ''}#{trait.amount} #{trait.title}"
 
+p Share your tree: #{tree_path(@tree.public_uuid)}

--- a/db/migrate/20171205003100_add_shareable_link_guid.rb
+++ b/db/migrate/20171205003100_add_shareable_link_guid.rb
@@ -1,0 +1,5 @@
+class AddShareableLinkGuid < ActiveRecord::Migration[5.1]
+  def change
+    add_column :trees, :public_uuid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171031005122) do
+ActiveRecord::Schema.define(version: 20171205003100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 20171031005122) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.string "public_uuid"
   end
 
   create_table "users", force: :cascade do |t|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -11,3 +11,7 @@ Given 'I sign in' do
     And I press "Log in"
   }
 end
+
+Given /^I visit "([^"]*)"$/ do |path|
+  visit path
+end

--- a/features/trees/public_uuid.feature
+++ b/features/trees/public_uuid.feature
@@ -1,0 +1,7 @@
+Feature: Public UUID
+
+  Scenario: Tree can be accessed by public link without authentication
+    Given there is a user with the email "user@example.com" and the password "Password1"
+    And there is a tree with the name "My Tree" and the user "user@example.com" and public_uuid "abcdefg"
+    And I visit "/trees/abcdefg"
+    Then I should see "My Tree"

--- a/lib/node_tree.rb
+++ b/lib/node_tree.rb
@@ -1,7 +1,7 @@
 class NodeTree
   attr_reader :tree
 
-  delegate :id, :name, to: :tree
+  delegate :id, :name, :public_uuid, to: :tree
 
   def initialize(tree)
     @tree = tree


### PR DESCRIPTION
# Changelog

* Trees now have a Uuid that can be used in a shareable link to give unauthenticated access to tree.